### PR TITLE
Problem: don't enforce nightly toolchain by default

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Solution:
- add a simple rust-toolchain file